### PR TITLE
Feature/add tagging params

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,31 @@ stacks:
       SAMLUsername: *SAML_USERNAME
 ```
 
+You can also tag your stacks/stacksets by defining your tags as a dictionary and referencing them using the YAML anchors within your stacks like this:
+
+```
+tags_a: &TAGSA
+  testkey1: testvalue1
+  testkey2: testvalue2
+  
+tags_b: &TAGSB
+  testkey3: testvalue3
+  
+  stacks:
+  - name: example-stackset-template
+    type: stackset
+    template: sets/example-stackset-template.cf.yaml
+    rollout:
+      - account: '000000000000'
+    tags: *TAGA
+
+  - name: my-project-kms-decrypt-lambda
+    template: support/kms-parameters-lambda.cf.yaml
+    parameters:
+      LambdaSourceS3Key: !LambdaZip kmsParameters.zip
+    tags: *TAGSB
+```
+
 #### `stacks`
 
 Main configuration where you describe the Cloudformation stacks you want to deploy.

--- a/cloudformation_seed/cfn_stack.py
+++ b/cloudformation_seed/cfn_stack.py
@@ -48,9 +48,9 @@ class CloudformationStack(object):
 
     def validate_tags(self, tags_passed):
         for k, v in tags_passed.items():
-            if len(k) > 128:
+            if len(k) > 127:
                 raise RuntimeError('Tag Key {0} cannot be more than 127 characters long'.format(k))
-            if len(v) > 256:
+            if len(v) > 255:
                 raise RuntimeError('Tag Value {0} cannot be more than 255 characters long'.format(v))
         self.format_tags(tags_passed)
 

--- a/cloudformation_seed/cfn_stack.py
+++ b/cloudformation_seed/cfn_stack.py
@@ -48,7 +48,7 @@ class CloudformationStack(object):
         print(self.stack_tags)
 
     def validate_tags(self, tags_passed):
-        for k,v in tags_passed.items():
+        for k, v in tags_passed.items():
             if len(k) > 129:
                 raise RuntimeError('Tag Key {0} cannot be more than 128 characters long'.format(k))
             if len(v) > 257:
@@ -101,7 +101,8 @@ class CloudformationStack(object):
                     StackName=self.stack_name,
                     TemplateURL=self.template.template_url,
                     Parameters=p,
-                    Capabilities=self.caps
+                    Capabilities=self.caps,
+                    Tags=[]
                 )
             self.wait('stack_update_complete')
         except ClientError as e:

--- a/cloudformation_seed/cfn_stack.py
+++ b/cloudformation_seed/cfn_stack.py
@@ -19,6 +19,7 @@ class CloudformationStack(object):
         self.existing_stack = self.find_existing_stack()
         self.caps = ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND']
         self.stack = None
+        self.stack_tags = None
 
     def set_parameters(self, parameters: util.StackParameters) -> None:
         self.stack_parameters = parameters
@@ -42,17 +43,39 @@ class CloudformationStack(object):
                 log.debug(f'Output {self.stack_name}.{output_name} = {xo["OutputValue"]}')
                 return xo['OutputValue']
 
+    def format_tags(self, tags_passed):
+        self.stack_tags = [{'Key': k, 'Value': str(v)} for k, v in tags_passed.items() if v is not None]
+        print(self.stack_tags)
+
+    def validate_tags(self, tags_passed):
+        for k,v in tags_passed.items():
+            if len(k) > 129:
+                raise RuntimeError('Tag Key {0} cannot be more than 128 characters long'.format(k))
+            if len(v) > 257:
+                raise RuntimeError('Tag Value {0} cannot be more than 256 characters long'.format(v))
+        self.format_tags(tags_passed)
+
     def create_stack(self) -> None:
         c = util.session.client('cloudformation')
         log.info(f'Creating stack {Fore.GREEN}{self.stack_name}{Style.RESET_ALL} with template'
             f' {Fore.GREEN}{self.template.template_url}{Style.RESET_ALL}')
-        c.create_stack(
-            StackName=self.stack_name,
-            TemplateURL=self.template.template_url,
-            Parameters=self.stack_parameters.format_parameters(),
-            DisableRollback=True,
-            Capabilities=self.caps
-        )
+        if self.stack_tags:
+            c.create_stack(
+                StackName=self.stack_name,
+                TemplateURL=self.template.template_url,
+                Parameters=self.stack_parameters.format_parameters(),
+                DisableRollback=True,
+                Capabilities=self.caps,
+                Tags=self.stack_tags
+            )
+        else:
+            c.create_stack(
+                StackName=self.stack_name,
+                TemplateURL=self.template.template_url,
+                Parameters=self.stack_parameters.format_parameters(),
+                DisableRollback=True,
+                Capabilities=self.caps
+            )
         self.wait('stack_create_complete')
         self.retrieve()
 
@@ -65,12 +88,21 @@ class CloudformationStack(object):
         log.debug(p)
         log.debug('-'.center(48, '-'))
         try:
-            c.update_stack(
-                StackName=self.stack_name,
-                TemplateURL=self.template.template_url,
-                Parameters=p,
-                Capabilities=self.caps
-            )
+            if self.stack_tags:
+                c.update_stack(
+                    StackName=self.stack_name,
+                    TemplateURL=self.template.template_url,
+                    Parameters=p,
+                    Capabilities=self.caps,
+                    Tags=self.stack_tags
+                )
+            else:
+                c.update_stack(
+                    StackName=self.stack_name,
+                    TemplateURL=self.template.template_url,
+                    Parameters=p,
+                    Capabilities=self.caps
+                )
             self.wait('stack_update_complete')
         except ClientError as e:
             if e.response['Error']['Message'] == 'No updates are to be performed.':

--- a/cloudformation_seed/cfn_stack.py
+++ b/cloudformation_seed/cfn_stack.py
@@ -19,7 +19,7 @@ class CloudformationStack(object):
         self.existing_stack = self.find_existing_stack()
         self.caps = ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND']
         self.stack = None
-        self.stack_tags = None
+        self.stack_tags = []
 
     def set_parameters(self, parameters: util.StackParameters) -> None:
         self.stack_parameters = parameters
@@ -45,37 +45,27 @@ class CloudformationStack(object):
 
     def format_tags(self, tags_passed):
         self.stack_tags = [{'Key': k, 'Value': str(v)} for k, v in tags_passed.items() if v is not None]
-        print(self.stack_tags)
 
     def validate_tags(self, tags_passed):
         for k, v in tags_passed.items():
-            if len(k) > 129:
-                raise RuntimeError('Tag Key {0} cannot be more than 128 characters long'.format(k))
-            if len(v) > 257:
-                raise RuntimeError('Tag Value {0} cannot be more than 256 characters long'.format(v))
+            if len(k) > 128:
+                raise RuntimeError('Tag Key {0} cannot be more than 127 characters long'.format(k))
+            if len(v) > 256:
+                raise RuntimeError('Tag Value {0} cannot be more than 255 characters long'.format(v))
         self.format_tags(tags_passed)
 
     def create_stack(self) -> None:
         c = util.session.client('cloudformation')
         log.info(f'Creating stack {Fore.GREEN}{self.stack_name}{Style.RESET_ALL} with template'
             f' {Fore.GREEN}{self.template.template_url}{Style.RESET_ALL}')
-        if self.stack_tags:
-            c.create_stack(
-                StackName=self.stack_name,
-                TemplateURL=self.template.template_url,
-                Parameters=self.stack_parameters.format_parameters(),
-                DisableRollback=True,
-                Capabilities=self.caps,
-                Tags=self.stack_tags
-            )
-        else:
-            c.create_stack(
-                StackName=self.stack_name,
-                TemplateURL=self.template.template_url,
-                Parameters=self.stack_parameters.format_parameters(),
-                DisableRollback=True,
-                Capabilities=self.caps
-            )
+        c.create_stack(
+            StackName=self.stack_name,
+            TemplateURL=self.template.template_url,
+            Parameters=self.stack_parameters.format_parameters(),
+            DisableRollback=True,
+            Capabilities=self.caps,
+            Tags=self.stack_tags
+        )
         self.wait('stack_create_complete')
         self.retrieve()
 
@@ -88,22 +78,14 @@ class CloudformationStack(object):
         log.debug(p)
         log.debug('-'.center(48, '-'))
         try:
-            if self.stack_tags:
-                c.update_stack(
-                    StackName=self.stack_name,
-                    TemplateURL=self.template.template_url,
-                    Parameters=p,
-                    Capabilities=self.caps,
-                    Tags=self.stack_tags
-                )
-            else:
-                c.update_stack(
-                    StackName=self.stack_name,
-                    TemplateURL=self.template.template_url,
-                    Parameters=p,
-                    Capabilities=self.caps,
-                    Tags=[]
-                )
+            c.update_stack(
+                StackName=self.stack_name,
+                TemplateURL=self.template.template_url,
+                Parameters=p,
+                Capabilities=self.caps,
+                Tags=self.stack_tags
+            )
+
             self.wait('stack_update_complete')
         except ClientError as e:
             if e.response['Error']['Message'] == 'No updates are to be performed.':

--- a/cloudformation_seed/cfn_stackset.py
+++ b/cloudformation_seed/cfn_stackset.py
@@ -253,9 +253,9 @@ class CloudformationStackSet(object):
     def validate_tags(self, tags_passed):
         self.stack_tags = tags_passed
         for k, v in tags_passed.items():
-            if len(k) > 128:
+            if len(k) > 127:
                 raise RuntimeError('Tag Key {0} cannot be more than 127 characters long'.format(k))
-            if len(v) > 256:
+            if len(v) > 255:
                 raise RuntimeError('Tag Value {0} cannot be more than 255 characters long'.format(v))
         self.format_tags(tags_passed)
 

--- a/cloudformation_seed/cfn_stackset.py
+++ b/cloudformation_seed/cfn_stackset.py
@@ -202,6 +202,8 @@ class CloudformationStackSet(object):
         self.caps = ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND']
         self.stack = None
         self.stackset_rollout: Optional[StackSetRollout] = None
+        self.stack_tags = None
+        self.formatted_stack_tags = None
 
     def retry_pending(f):
         @wraps(f)
@@ -235,20 +237,50 @@ class CloudformationStackSet(object):
             log.info(f'Stackset {Fore.GREEN}{self.stack_name}{Style.RESET_ALL} does not exist')
             return None
 
+    def tags_need_update(self):
+        c = util.session.client('cloudformation')
+        response = c.describe_stack_set(StackSetName=self.stack_name)
+        if response['StackSet']['Tags'] != self.formatted_stack_tags:
+            return True
+        else:
+            return False
+
     def get_stack_output(self, output_name: str) -> NoReturn:
         raise util.InvalidStackConfiguration(f'Can\'t retrieve output {output_name} '
                                                      f'of stackset {self.stack_name}'
                                         f', stacksets don\'t have outputs. Please review your configuration')
 
+    def format_tags(self, tags_passed):
+        self.formatted_stack_tags = [{'Key': k, 'Value': str(v)} for k, v in tags_passed.items() if v is not None]
+        print(self.stack_tags)
+
+    def validate_tags(self, tags_passed):
+        self.stack_tags = tags_passed
+        for k, v in tags_passed.items():
+            if len(k) > 129:
+                raise RuntimeError('Tag Key {0} cannot be more than 128 characters long'.format(k))
+            if len(v) > 257:
+                raise RuntimeError('Tag Value {0} cannot be more than 256 characters long'.format(v))
+        self.format_tags(tags_passed)
+
     @retry_pending
     def create_stackset(self) -> None:
         c = util.session.client('cloudformation')
-        params: Dict[str, Any] = {
-            'StackSetName': self.stack_name,
-            'TemplateURL': self.template.template_url,
-            'Parameters': self.stack_parameters.format_parameters(),
-            'Capabilities': self.caps
-        }
+        if self.stack_tags:
+            params: Dict[str, Any] = {
+                'StackSetName': self.stack_name,
+                'TemplateURL': self.template.template_url,
+                'Parameters': self.stack_parameters.format_parameters(),
+                'Capabilities': self.caps,
+                'Tags': self.formatted_stack_tags
+            }
+        else:
+            params: Dict[str, Any] = {
+                'StackSetName': self.stack_name,
+                'TemplateURL': self.template.template_url,
+                'Parameters': self.stack_parameters.format_parameters(),
+                'Capabilities': self.caps
+            }
         params.update(self.stack_parameters.format_role_pair())
         log.info(f'Creating stackset {Fore.GREEN}{self.stack_name}{Style.RESET_ALL} with template'
             f' {Fore.GREEN}{self.template.template_url}{Style.RESET_ALL}')
@@ -278,7 +310,14 @@ class CloudformationStackSet(object):
                 stackset_name=self.stack_name,
                 color=Fore.GREEN,
                 color_reset=Style.RESET_ALL))
-        return parameters_changed or template_changed
+        tags_changed: bool = \
+            self.tags_need_update()
+        log.info('Tags are {color}{is_changing}{color_reset} for stackset {color}{stackset_name}{color_reset}'
+            .format(is_changing='changing' if tags_changed else 'not changing',
+                stackset_name=self.stack_name,
+                color=Fore.GREEN,
+                color_reset=Style.RESET_ALL))
+        return parameters_changed or template_changed or tags_changed
 
     @retry_pending
     def update_stackset(self) -> None:
@@ -293,12 +332,22 @@ class CloudformationStackSet(object):
         log.debug(' Parameters '.center(48, '-'))
         log.debug(p)
         log.debug('-'.center(48, '-'))
-        params = {
-            'StackSetName': self.stack_name,
-            'TemplateURL': self.template.template_url,
-            'Parameters': p,
-            'Capabilities': self.caps,
-        }
+        if self.stack_tags:
+            params = {
+                'StackSetName': self.stack_name,
+                'TemplateURL': self.template.template_url,
+                'Parameters': p,
+                'Capabilities': self.caps,
+                'Tags': self.formatted_stack_tags
+            }
+        else:
+            params = {
+                'StackSetName': self.stack_name,
+                'TemplateURL': self.template.template_url,
+                'Parameters': p,
+                'Capabilities': self.caps,
+                'Tags': []
+            }
         params.update(self.stack_parameters.format_role_pair())
         params.update(self.stack_parameters.format_operation_preferences())
         c.update_stack_set(**params)

--- a/cloudformation_seed/cfn_template.py
+++ b/cloudformation_seed/cfn_template.py
@@ -1,6 +1,6 @@
 from cloudformation_seed import s3_classes, util
 
-from typing import Dict, List, Any, Tuple
+from typing import Dict, List, Any, Tuple, Optional
 from colorama import Fore, Style
 
 import os
@@ -41,6 +41,11 @@ class CloudformationTemplate(object):
     @property
     def name(self) -> str:
         return self.template_parameters['name']
+
+    @property
+    def tags(self):
+        if 'tags' in self.template_parameters:
+            return self.template_parameters['tags']
 
     @property
     def template(self) -> str:

--- a/cloudformation_seed/cfn_template.py
+++ b/cloudformation_seed/cfn_template.py
@@ -46,6 +46,8 @@ class CloudformationTemplate(object):
     def tags(self):
         if 'tags' in self.template_parameters:
             return self.template_parameters['tags']
+        else:
+            return None
 
     @property
     def template(self) -> str:

--- a/cloudformation_seed/cfn_template.py
+++ b/cloudformation_seed/cfn_template.py
@@ -47,7 +47,7 @@ class CloudformationTemplate(object):
         if 'tags' in self.template_parameters:
             return self.template_parameters['tags']
         else:
-            return None
+            return []
 
     @property
     def template(self) -> str:

--- a/cloudformation_seed/cfn_template.py
+++ b/cloudformation_seed/cfn_template.py
@@ -1,6 +1,6 @@
 from cloudformation_seed import s3_classes, util
 
-from typing import Dict, List, Any, Tuple, Optional
+from typing import Dict, List, Any, Tuple
 from colorama import Fore, Style
 
 import os

--- a/cloudformation_seed/examples/cloudformation/sets/example-stackset-template.cf.yaml
+++ b/cloudformation_seed/examples/cloudformation/sets/example-stackset-template.cf.yaml
@@ -1,0 +1,57 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Simple "hello world" lambda for testing purposes
+
+Parameters:
+  TemplatesS3Bucket:
+    Type: String
+    Description: S3 Bucket with the components templates
+  InstallationName:
+    Type: String
+    Description: Unique stack installation name
+  RuntimeEnvironment:
+    Type: String
+    Description: The runtime environment config tag
+    Default: dev
+  Route53ZoneDomain:
+    Type: String
+    Description: Route53 zone domain that represents the environment
+
+Resources:
+  LambdaRole:
+      Type: "AWS::IAM::Role"
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: "Allow"
+              Principal:
+                Service:
+                  - "lambda.amazonaws.com"
+              Action:
+                - "sts:AssumeRole"
+        Policies:
+          - PolicyName: "CloudwatchLogs"
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: "Allow"
+                  Action:
+                    - "logs:CreateLogGroup"
+                    - "logs:CreateLogStream"
+                    - "logs:PutLogEvents"
+                    - "logs:DescribeLogStreams"
+                  Resource: "arn:aws:logs:*:*:*"
+  Lambda:
+    Type: "AWS::Lambda::Function"
+    Properties:
+        Description: Say hello
+        Handler:
+            index.lambda_handler
+        Runtime: "python3.6"
+        Role: !GetAtt LambdaRole.Arn
+        Timeout: 15
+        Code:
+          ZipFile: !Sub |
+            #!/usr/bin/env python
+            def lambda_handler(event, context):
+                print("Hello world!")

--- a/cloudformation_seed/examples/parameters/dev.yaml
+++ b/cloudformation_seed/examples/parameters/dev.yaml
@@ -1,23 +1,43 @@
 ---
 
+tags_a: &TAGSA
+  testkey1: testvalue1
+  testkey2: testvalue2
+
+tags_b: &TAGSB
+  testkey3: testvalue3
+
+tags_c: &TAGSC
+  testkey4: testvalue4
+
 AllConnectedAccounts: &CONNECTED_ACCOUNTS arn:aws:iam::000000000000:root,arn:aws:iam::111111111111:root,arn:aws:iam::222222222222:root
 
 common-parameters:
   KmsDecryptLambdaArn: !StackOutput my-project-kms-decrypt-lambda.KmsDecryptLambdaArn
 
 stacks:
+  - name: example-stackset-template
+    type: stackset
+    template: sets/example-stackset-template.cf.yaml
+    rollout:
+      - account: '000000000000'
+    tags: *TAGSC
+
   - name: my-project-kms-decrypt-lambda
     template: support/kms-parameters-lambda.cf.yaml
     parameters:
       LambdaSourceS3Key: !LambdaZip kmsParameters.zip
+    tags: *TAGSA
 
   - name: centralservices-s3-watchdog-lambda
     template: support/s3-watchdog-lambda.cf.yaml
+    tags: *TAGSA
 
   - name: centralservices-bucket-policy
     template: support/bucket-policy.cf.yaml
     parameters:
       ConnectedAccountArns: *CONNECTED_ACCOUNTS
+    tags: *TAGSB
 
   - name: my-project
     template: my-project.cf.yaml
@@ -26,6 +46,7 @@ stacks:
       PrivateSubnets: subnet-00000000,subnet-00000000
       ServerInstanceType: t2.small
       ServerAmi: ami-9d58b6ff
+    tags: *TAGSC
 
 
 # vim: ts=2 sw=2 expandtab

--- a/cloudformation_seed/stack_deployer.py
+++ b/cloudformation_seed/stack_deployer.py
@@ -61,6 +61,8 @@ class StackParser(object):
             util.log_section(f'Deploying {xs.template.template_type} {xs.stack_name}')
             p = util.StackParameters(self.s3_bucket, xs.template, self.manifest, self.options, self)
             xs.set_parameters(p)
+            if xs.template.tags:
+                xs.validate_tags(xs.template.tags)
             xs.deploy()
             util.log_section(f'{xs.stack_name} deployment complete')
 

--- a/cloudformation_seed/util.py
+++ b/cloudformation_seed/util.py
@@ -273,6 +273,7 @@ class StackParameters(object):
         log.debug(f'Found image name {val} for artifact {artifact_name}...')
         return val
 
+
     def read_parameters_yaml(self, filename):
         with open(filename, 'r') as f:
             return yaml.load(f, Loader=self.parameters_loader)

--- a/cloudformation_seed/util.py
+++ b/cloudformation_seed/util.py
@@ -273,7 +273,6 @@ class StackParameters(object):
         log.debug(f'Found image name {val} for artifact {artifact_name}...')
         return val
 
-
     def read_parameters_yaml(self, filename):
         with open(filename, 'r') as f:
             return yaml.load(f, Loader=self.parameters_loader)


### PR DESCRIPTION
Adding the tagging feature to stacks and stacksets. 

Tags are defined in the parameters/{env}.yaml file and by using the YAML anchors they can be attached to the either the stacks or the stacksets. Adding, updating and removing tags has been tested and working as expected.

This PR is related to issue #21 