### PR TITLE
Release ARM64/M1 Docker container alongside AMD64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,5 +77,6 @@ jobs:
           build-args: |
             CFSEED_VERSION=${{ env.RELEASE_TAG }}
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Running AMD64 Docker containers on M1 Macs is quite annoying, particularly in build processes.  This pull request updates the Github Actions workflow to build and release an ARM64/M1 version of the `cf-seed` Docker container along with the AMD64 version.

**Note to self:** PR is still in draft, as I haven't tested the ARM64 build locally yet.